### PR TITLE
Feature/project level permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ As a template:
 
 ```
 
+### permission
+
+- Required: `N`
+- Default: `guest`
+
+### permissionErrorMessage
+
+- Required: `N`
+- Default: `You must be logged in to view this page`
+
 ## Writing Documentation
 
 All documentation is written in Markdown with some added bonuses. Check [Markdown Guide](https://www.markdownguide.org/extended-syntax/) for a reference on how to write Markdown. In addition to the basics, you may also include [tables](https://www.markdownguide.org/extended-syntax/#tables) and [code blocks](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks).

--- a/lib/guide.js
+++ b/lib/guide.js
@@ -20,6 +20,8 @@ In your module, be sure to include a sections key.`
 
   options.path = options.path || 'guide';
   options.public = options.public || false;
+  options.permission = options.permission || 'guest';
+  options.permissionErrorMessage = options.permissionErrorMessage || 'You must be logged in to view this page';
 
   const stylesheets = options.stylesheets;
   const scripts = options.scripts;
@@ -36,13 +38,11 @@ In your module, be sure to include a sections key.`
     path: options.path
   };
 
-  const permissionErrorMessage = 'You must be logged in to view this page';
-
   self.addRoutes = () => {
     self.apos.app.get(`/${options.path}`, (req, res) => {
       if (!canView(req)) {
         res.statusCode = 403;
-        return res.send(permissionErrorMessage);
+        return res.send(options.permissionErrorMessage);
       }
 
       const sections = setActive(
@@ -90,7 +90,7 @@ In your module, be sure to include a sections key.`
   function canView(req) {
     return (
       options.public === true ||
-      (options.public === false && self.apos.permissions.can(req, 'guest'))
+      (options.public === false && self.apos.permissions.can(req, options.permission))
     );
   }
 
@@ -99,7 +99,7 @@ In your module, be sure to include a sections key.`
       self.apos.app.get(demo, (req, res) => {
         if (!canView(req)) {
           res.statusCode = 403;
-          return res.send(permissionErrorMessage);
+          return res.send(options.permissionErrorMessage);
         }
         const template = path.basename(demo);
         return self.sendPage(req, `demos/${template}`, { ...data });
@@ -123,7 +123,7 @@ In your module, be sure to include a sections key.`
     self.apos.app.get(`${url}`, (req, res) => {
       if (!canView(req)) {
         res.statusCode = 403;
-        return res.send(permissionErrorMessage);
+        return res.send(options.permissionErrorMessage);
       }
 
       const sections = setActive(self.data.sections, page);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "apostrophe": "^2.108.1"
   },
   "devDependencies": {
+    "apostrophe": "^2.116.1",
     "eslint": "^7.4.0",
     "eslint-config-apostrophe": "^3.2.0",
     "eslint-config-standard": "^14.1.1",


### PR DESCRIPTION
Resolves Issue #7 

---

Per my conversation with @boutell I added apostrophe as a dev dependency to get tests in `test/pages.js` passing. I still ran into linter errors below when the pre-commit tests ran and bypassed via `--no-verify`.

`525252 problems (365695 errors, 159557 warnings)
  322750 errors and 159549 warnings potentially fixable with the `--fix` option.`